### PR TITLE
Add descriptions, A4xCalc

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -10,5 +10,11 @@
     "Type": "RootUtility",
     "Description": "Some description",
     "Updates": "https://raw.githubusercontent.com/Aurora-Modders/AuroraMods/master/Mods/AuroraElectrons/updates.txt"
+  },
+  {
+      "Name": "A4xCalc",
+      "Type": "Utility",
+      "Description": "Some description",
+      "Updates": "A4xCalc=https://raw.githubusercontent.com/Aurora-Modders/AuroraMods/master/Mods/A4xCalc/updates.txt"
   }
 ]

--- a/mods.json
+++ b/mods.json
@@ -2,19 +2,19 @@
   {
     "Name": "AuroraMod",
     "Type": "Exe",
-    "Description": "Some description",
+    "Description": "Replaces aurora.exe and provides custom themes, window resizing and persistence, autosave, and other QoL features",
     "Updates": "https://raw.githubusercontent.com/Aurora-Modders/AuroraMods/master/Mods/AuroraMod/updates.txt"
   },
   {
     "Name": "AuroraElectrons",
     "Type": "RootUtility",
-    "Description": "Some description",
+    "Description": "A slick modern app for sorting and visualizing mining and production. Also includes an engine optimizer.",
     "Updates": "https://raw.githubusercontent.com/Aurora-Modders/AuroraMods/master/Mods/AuroraElectrons/updates.txt"
   },
   {
       "Name": "A4xCalc",
       "Type": "Utility",
-      "Description": "Some description",
+      "Description": "A feature-rich calculator for optimizing missile and ship builds",
       "Updates": "https://raw.githubusercontent.com/Aurora-Modders/AuroraMods/master/Mods/A4xCalc/updates.txt"
   }
 ]

--- a/mods.json
+++ b/mods.json
@@ -15,6 +15,6 @@
       "Name": "A4xCalc",
       "Type": "Utility",
       "Description": "Some description",
-      "Updates": "A4xCalc=https://raw.githubusercontent.com/Aurora-Modders/AuroraMods/master/Mods/A4xCalc/updates.txt"
+      "Updates": "https://raw.githubusercontent.com/Aurora-Modders/AuroraMods/master/Mods/A4xCalc/updates.txt"
   }
 ]


### PR DESCRIPTION
The A4xCalc link should work with 0.20.0 but the execution command needs a fix in https://github.com/Aurora-Modders/AuroraLoader/pull/13 in order to work (although it shouldn't crash or throw an error or anything).