### PR TITLE
Fix the url for the aurora-component-sorter mod

### DIFF
--- a/mod_locations.json
+++ b/mod_locations.json
@@ -6,5 +6,5 @@
     "https://raw.githubusercontent.com/Aurora-Modders/community_wiki_links/master/mod.json",
     "https://github.com/Aurora-Modders/AuroraElectrons/raw/master/mod.json",
     "https://bitbucket.org/zap0/renamecomponentsizes/raw/07fe59a4ea3b42650ad662505aade886d3d3049d/Rename%20Component%20Sizes/mod.json",
-    "https://gitlab.com/db48x/aurora-component-sorter/-/archive/v1.0.0/aurora-component-sorter-v1.0.0.zip"
+    "https://gitlab.com/db48x/aurora-component-sorter/-/raw/master/mod.json"
 ]


### PR DESCRIPTION
I must have copied the wrong url, or otherwise pasted the same url twice.

Thanks!